### PR TITLE
Fix report pathname creation (under Clozure CL)

### DIFF
--- a/dev/config.lisp
+++ b/dev/config.lisp
@@ -287,7 +287,7 @@ use asdf:test-op or bind *current-asdf-system-name* yourself."))))))
 		    (when old-name
 		      (setf destination
 			    (merge-pathnames
-			     (make-pathname :directory `(:relative ,old-name))
+			     (make-pathname :directory `(:relative ,@(split old-name '(#\/))))
 			     destination)))
 		    (print destination)
 		    (merge-pathnames


### PR DESCRIPTION
REPORT-PATHNAME around method calls MAKE-PATHNAME and specifying
:directory by a relative directory component which in some (all?)
cases contains a directory separator (slash), which at least on my
Linux system is not a valid file name character (and Clozure CL
rightfully complains about it).

I'm not sure the fix is completely right, because I run into it while
testing cl-markdown, and the tests do not work in SBCL because of some
deadlock problems (so I cannot compare if the fixed version creates
same directory tree as before the fix).
