### PR TITLE
Make failed ENSURE remember its predicate's arguments

### DIFF
--- a/dev/lift.lisp
+++ b/dev/lift.lisp
@@ -74,9 +74,10 @@
   "Test ran out of time (longer than ~S-second~:P)" 
   maximum-time)
 
-(defcondition (ensure-failed-error  :slot-names (message)) (test-condition) 
-  ((assertion :initform ""))
-   "Ensure failed: ~S ~@[(~a)~]" assertion message)
+(defcondition (ensure-failed-error  :slot-names (message)) (test-condition)
+  ((assertion :initform "")
+   (called-as :initform ""))
+   "Ensure failed: ~S~%Called as: ~S ~@[(~a)~]" assertion called-as message)
 
 (defcondition (ensure-null-failed-error :slot-names (message)) (ensure-failed-error)
   ((value :initform "")

--- a/dev/macros.lisp
+++ b/dev/macros.lisp
@@ -314,6 +314,7 @@ will generate a message like
         (gpredicate (gensym "RESULT"))
         (gargs (gensym "ARGS")))
     (if (and (symbolp func-name)
+			 (fboundp func-name)
              (not (macro-function func-name)))
         `(let* ((,gargs (list ,@(rest predicate)))
                 (,gpredicate (apply #',(first predicate) ,gargs)))

--- a/dev/macros.lisp
+++ b/dev/macros.lisp
@@ -310,19 +310,37 @@ will generate a message like
 
     Warning: Ensure failed: (= 23 12) (I hope 12 does not = 23)
 "
-  (let ((gpredicate (gensym)))
-    `(let ((,gpredicate ,predicate))
-       (if ,gpredicate
-	   (values ,gpredicate)
-	   (let ((condition (make-condition
-			     'ensure-failed-error
-			     :assertion ',predicate
-			     ,@(when report
-				     `(:message
-				       (format nil ,report ,@arguments))))))
-	     (if (find-restart 'ensure-failed)
-		 (invoke-restart 'ensure-failed condition)
-		 (warn condition)))))))
+  (let ((func-name (first predicate))
+        (gpredicate (gensym "RESULT"))
+        (gargs (gensym "ARGS")))
+    (if (and (symbolp func-name)
+             (not (macro-function func-name)))
+        `(let* ((,gargs (list ,@(rest predicate)))
+                (,gpredicate (apply #',(first predicate) ,gargs)))
+           (if ,gpredicate
+               (values ,gpredicate)
+               (let ((condition (make-condition
+                                 'ensure-failed-error
+                                 :assertion ',predicate
+                                 :called-as (list* ',(first predicate) ,gargs)
+                                 ,@(when report
+                                         `(:message
+                                           (format nil ,report ,@arguments))))))
+                 (if (find-restart'ensure-failed)
+                     (invoke-restart'ensure-failed condition)
+                     (warn condition)))))
+        `(let ((,gpredicate ,predicate))
+           (if ,gpredicate
+               (values ,gpredicate)
+               (let ((condition (make-condition
+                                 'ensure-failed-error
+                                 :assertion ',predicate
+                                 ,@(when report
+                                         `(:message
+                                           (format nil ,report ,@arguments))))))
+                 (if (find-restart 'ensure-failed)
+                     (invoke-restart 'ensure-failed condition)
+                     (warn condition))))))))
 
 (defmacro ensure-null (predicate &key report arguments)
   "If ensure-null's `predicate` evaluates to true, then it will generate a


### PR DESCRIPTION
And report them with the called form.

I seem to have messed up some formatting. Do you use tabstop=8?
